### PR TITLE
updated links to MDN js chapters

### DIFF
--- a/content/kurser/javascript1/kmom01.md
+++ b/content/kurser/javascript1/kmom01.md
@@ -53,8 +53,8 @@ Läs följande:
 4. [MDN Tutorial: Getting started with CSS](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Getting_started). Gå snabbt igenom guiden (Part I: The Basics of CSS) översiktligt för att bekanta dig med CSS och se vad du kan göra med CSS. 
 
 5. Bekanta dig med guiden [MDN JavaScript Guide](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide) och läs följande kapitel.
-    * [Ch 3: JavaScript Overview](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/JavaScript_Overview) en kort introduktion till JavaScript.
-    * [Ch 4: Values, variables, and literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Values,_variables,_and_literals)
+    * [Ch 1: Introduction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Introduction) en kort introduktion till JavaScript.
+    * [Ch 2: Grammar and types](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types)
 
 
 


### PR DESCRIPTION
MDN-guiden har möblerats om och de tidigare länkarna omdirigeras automatiskt till nya länkar.

[Ch 3: JavaScript Overview](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/JavaScript_Overview) har blivit [Ch 1: Introduction](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Introduction)

[Ch 4: Values, variables, and literals](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Values,_variables,_and_literals) har blivit [Ch 2: Grammar and types](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types)
