### PR TITLE
removed python from htmlphp

### DIFF
--- a/content/uppgift/190_bygg-en-stylevaljare-till-din-webbplats.md
+++ b/content/uppgift/190_bygg-en-stylevaljare-till-din-webbplats.md
@@ -68,7 +68,7 @@ Krav {#krav}
 1. Validera och publicera din kod enligt följande.
 
 ```bash
-# Ställ dig i roten av kurskatalogen för python
+# Ställ dig i roten av kurskatalogen
 dbwebb publish stylechooser
 ```
 


### PR DESCRIPTION
Sagt i https://gitter.im/dbwebb-se/htmlphp

> Danne97 <@Danne97> Sep 24 18:18
> På sidan där uppgift kmom04 stylechooser finns,
> https://dbwebb.se/uppgift/bygg-en-stylevaljare-till-din-webbplats
> finns så är det ett litet fel. det står:
> > Ställ dig i roten av kurskatalogen för python
> 
> det borde stå htmlphp istället för python. kanske förvirrar någon
> 
> Viktor Barrios <@vict0rbarrios_twitter> Sep 24 18:19
> ja jag såg det också hehe

Jag föreslår att ta bort kursens namn helt till och med.