### PR TITLE
removed double "```php" infront of code example

### DIFF
--- a/content/guide/kom-igang-med-objektorienterad-programmering-i-php/225_refactoring-av-klasser.md
+++ b/content/guide/kom-igang-med-objektorienterad-programmering-i-php/225_refactoring-av-klasser.md
@@ -74,7 +74,6 @@ Skillnaden är att den ärvande klassen kan få tillgång till medlemsvariabler 
 När variabeln är protected så skulle min metod kunna uppdateras till följande.
 
 ```php
-```php
 /**
  * Get a graphic value of the last rolled dice.
  *


### PR DESCRIPTION
The code example at line 76 had two opening statemets for the code section. Removed one of them.