### PR TITLE
Corrects tag version for an article in design course

### DIFF
--- a/content/uppgift/1177_bygg-ett-tema-med-vertikalt-och-horisontellt-grid.md
+++ b/content/uppgift/1177_bygg-ett-tema-med-vertikalt-och-horisontellt-grid.md
@@ -111,7 +111,7 @@ Krav {#krav}
 
 1. Gör en `dbwebb publishpure redovisa` och kontrollera att allt fungerar på studentservern.
 
-1. Committa alla filer, inklusive temats filer och lägg till en (ny) tagg (2.0.\*).
+1. Committa alla filer, inklusive temats filer och lägg till en (ny) tagg (3.0.\*).
 
 1. Pusha repot till GitHub, inklusive taggarna.
 


### PR DESCRIPTION
The major version for the tags should reflect which kmom it is (e.g. kmom01 is v1.0.*). In order to keep consistency, this was updated from '2.0.*' to '3.0.*' to match kmom03.