### PR TITLE
Korrigera uppg 4 om HAVING

### DIFF
--- a/content/guide/kom-igang-med-sql-i-mysql/217_aggregerande-funktioner-having.md
+++ b/content/guide/kom-igang-med-sql-i-mysql/217_aggregerande-funktioner-having.md
@@ -261,7 +261,7 @@ Gör nu en egen rapport med GROUP BY och HAVING.
 1. Visa per avdelning hur många anställda det finns, gruppens snittlön, sortera per avdelning och snittlön.
 2. Visa samma sak som i 1), men visa nu även de kompetenser som finns. Du behöver gruppera på avdelning och per kompetens, sortera per avdelning och per kompetens.
 3. Visa samma sak som i 2), men ignorera de kompetenser som är större än 3.
-4. Visa samma sak som i 3), men exkludera de grupper som har fler än 1 i Antal och snittlön mellan 30 000 - 45 000. Sortera per snittlön.
+4. Visa samma sak som i 3), men exkludera de grupper som har fler än 1 i Antal eller inte har snittlön mellan 30 000 - 45 000. Sortera per snittlön.
 
 Ditt svar bör se ut så här.
 


### PR DESCRIPTION
"4. Visa samma sak som i 3), men exkludera de grupper som har fler än 1 i Antal och har snittlön mellan 30 000 - 45 000. Sortera per snittlön."
Instruktionen stämmer inte överens med svaret (rad 314). I svaret framgår att det är grupper som har snittlön mellan 30 000 - 45 000 som **behålls**. 

Eftersom negationerna i min korrigering blir lite förvirrande kanske det är bättre att använda 
"... men **behåll endast** de grupper som har **färre* än **2** i Antal **och** har snittlön mellan 30 000 - 45 000. Sortera per snittlön.".