### PR TITLE
Add -r flag to webapp kmom02

### DIFF
--- a/content/kunskap/1103_knappar-for-mobilen.md
+++ b/content/kunskap/1103_knappar-for-mobilen.md
@@ -193,7 +193,7 @@ För att installera SASS kan vi använda oss av `npm`.
 ```bash
 # Stå i me/kmom02/buttons
 npm init --yes
-npm install --save sass
+npm install --save-dev sass
 ```
 
 Kommandot `npm init --yes` skapar en fil `package.json` som är en konfigurationsfil för projekt som använder sig av npm.

--- a/content/kunskap/1104_struktur-i-var-javascript.md
+++ b/content/kunskap/1104_struktur-i-var-javascript.md
@@ -20,7 +20,7 @@ Du kan med fördel strukturera upp koden från uppgiften [Lager appen del 1](upp
 
 ```bash
 # stå i me-katalogen
-cp kmom01/lager1/* kmom02/lager2/
+cp -r kmom01/lager1/* kmom02/lager2/
 ```
 
 I den andra delen av artikeln från och med [Återanvända data](#caching) tittar vi ytterligare på hur vi kan strukturera vår kod. Vi delar upp hämtningen av data och renderingen av element i webbläsaren, så vi får kod som är lättare att återanvända.

--- a/content/uppgift/1141_lager-appen-del-2.md
+++ b/content/uppgift/1141_lager-appen-del-2.md
@@ -29,7 +29,7 @@ Börja med att kopiera din lager app från kmom01, om du inte gjorde det i övni
 
 ```bash
 # stå i me-katalogen
-cp kmom01/lager1/* kmom02/lager2/
+cp -r kmom01/lager1/* kmom02/lager2/
 ```
 
 Använd lager [API:t](https://lager.emilfolino.se/v2) dokumentationen och speciellt sektionen om order. Här kan du hämta ut ordern och alla orderrader. När du ska uppdatera lagersaldot använder du dig av `PUT` HTTP-metoden för produkterna.


### PR DESCRIPTION
The instructions for webapp kmom02 (lagerappen) were missing an `-r` flag in two places for copying from the last kmom.

Also made sass a dev dependency.

https://discord.com/channels/118332969004957705/694092511379062785/833278663708377089