### PR TITLE
Förtydliga hur Makefile.mvc kan användas

### DIFF
--- a/content/uppgift/1246_analysera-php-ramverk-och-valj-ut-ett-att-anvanda.md
+++ b/content/uppgift/1246_analysera-php-ramverk-och-valj-ut-ett-att-anvanda.md
@@ -90,7 +90,7 @@ Kraven är uppdelade i sektioner.
 
 Följande bör du klara av på egen hand. Om du av någon anledning får ont om tid eller inte klarar av detta så kan du hoppa över denna delen för tillfället och ändå lämna in ditt kursmoment. Men du bör notera eventuella problem och hinder och skapa issue om det i kursrepot.
 
-1. Kopiera din `Makefile` till ramverket och döp den till `Makefile.mvc`. Namnbytet är så att den inte krockar med någon annan Makefile som eventuellt redan ligger på plats.
+1. Kopiera din `Makefile` till ramverket och döp den till `Makefile.mvc`. Namnbytet är så att den inte krockar med någon annan Makefile som eventuellt redan ligger på plats. OBS! Om du vill använda den här filen med `make`-kommandot måste du ange filnamnet på det här sättet: `make -f Makefile.mvc phpunit`.
 
 1. Kopiera över alla konfigurationsfiler för validatorerna, men se till så att du inte skriver över någon fil som redan ligger i ramverket. Konfigurationsfilerna är de som heter `.php*` i din katalog `me/game`.
 


### PR DESCRIPTION
Flera, inklusive jag, har blivit förbryllade över att vi ska döpa om "Makefile" till "Makefile.mvc", men sen kan vi inte använda `make` som tidigare. Det här är helt att vänta, utifrån hur `make` letar efter makefiler, se [relevant sida av GNU Make Manual](https://www.gnu.org/software/make/manual/html_node/Makefile-Names.html). Förtydligandet jag föreslår här kan förhindra onödigt krångel för studenter.