### PR TITLE
Removed soft-recommendation to 8GB of RAM and Intel CPU recommendations

### DIFF
--- a/content/kurser/faq/102_ny-dator.md
+++ b/content/kurser/faq/102_ny-dator.md
@@ -2,6 +2,7 @@
 author: mos
 baseurl: null
 revision:
+    "2024-08-12": "(C, nik) Mindre uppdatering inför HT24."
     "2021-06-03": "(B, mos) Genomgången inför HT21."
     "2020-06-22": "(A, mos) Ny inför HT20."
 ...
@@ -16,17 +17,19 @@ Du kan välja Windows, Mac eller Linux. Alla fungerar med programvarorna vi anv�
 
 Du kan ha en bärbar eller stationär, välj efter eget tycke. Kanske en av varje?
 
+Tänk igenom om du kommer använda datorn till annat, då kanske du behöver mer lagring eller en mer kraftfull dator. Ibland kan det vara bra att ha en dator dedikerad till studier, det blir svårare att hitta på annat. Men det är viktigt att slappna av med.
+
 Om du går på campus så rekommenderas att du har en bärbar som du kan ha med dig till skolan och sitta och jobba på i labbsalarna eller i biblioteket. Även på distans kan det vara skönt att ha en bärbar och ha möjligheten att gå någon annanstans för att studera, kanske tillsammans med studiekompisar.
 
 Ha gärna flera skärmar, själv använder jag helst tre skärmar. Det ger mig en bra och effektiv arbetsyta.
 
-Köp gärna mycket primärminne. Själv hade jag valt 16GB eller mer. 8GB får räcka om plånboken är tunn. Är pengar ett mindre problem så väljer du gärna mer. Webbläsare äter minne och det är bra att ha minne för virtualisering (att köra en dator i din dator).
+Köp gärna mycket primärminne. Själv hade jag valt 16GB eller mer. Är pengar ett mindre problem så väljer du gärna mer. Webbläsare äter minne och det är bra att ha minne för virtualisering (att köra en dator i din dator).
 
 SSD-disk eller liknande är bra för hyffsat snabb dator. Vill du spara mycket data så vill du även ha en traditionell mekanisk hårddisk som ger dig extra utrymme, eller skaffa dig en bärbar USB-disk att ha som extra lagring. Se tilla tt du kan kopiera data mellan dina hårddiskar och på så sätt få en enkel backup.
 
 Det är bra att ha en lagringsmöjlighet på nätet, något i stil med DropBox, OneDrive, iCloud, Google Drive eller motsvarande. Se till att ha en backup i molnet.
 
-Processor CPU Intel I5 räcker, för egen del har jag I7. Det spelar inte så stor roll.
+Gällande processorer är generellt i3<i5<i7 för Intel och Ryzen 3<5<7 för AMD. Nyare är också oftast bättre (både i batteri och prestanda). Samma som tidigare, låt plånboken bestämma.
 
 I några kurser används virtualisering med Docker/VirtualBox och liknande. De allra nyaste datorerna klarar det bra medans äldre datorer kan vara svårare. För att vara på säkraste sidan så använd nyare datorer.
 


### PR DESCRIPTION
# Description

* Removed previous soft-recommendation of 8GB of RAM (as that is not a good recommendation for a computer in 2024)
* Updated reference to Intel i5/i7 as it doesn't provide a relevant guideline (ex an i7 3770K isn't really a great alternative to a more modern i3 or i5). Also added AMD reference
* Added paragraph about considerations when using the computer for other things than schoolwork